### PR TITLE
remove encoding declaration.

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import openai
 import os
 

--- a/index.py
+++ b/index.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from bottle import route, run, request
 from const import *
 from openai_message import (

--- a/openai_message.py
+++ b/openai_message.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from const import *
 
 def create_prompt_to_summarise_message(user_messages: str) -> list:

--- a/typetalk.py
+++ b/typetalk.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 from const import *
 import requests
 


### PR DESCRIPTION
> Code in the core Python distribution should always use UTF-8, and should not have an encoding declaration.

https://peps.python.org/pep-0008/#source-file-encoding